### PR TITLE
ci: Add protoc to Format & Lint workflow (st-dquwj)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install Protocol Buffers compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/rust-setup
         with:


### PR DESCRIPTION
HUMAN_APPROVED: st-dquwj

Enable presage dependency requires protobuf-compiler at build time.
This unblocks PR #51 (Enable presage dependency).

## Changes
- Add protoc installation to Format & Lint job in ci.yml
- Matches existing protoc setup in Test job (lines 44-45)

🤖 Generated by refinery merge queue processor