### PR TITLE
feat: Complete re-entry warning with Freenet query (GAP-10)

### DIFF
--- a/src/signal/bot.rs
+++ b/src/signal/bot.rs
@@ -216,7 +216,8 @@ impl<C: SignalClient, F: crate::freenet::FreenetClient> StromaBot<C, F> {
         // Phase 1: Query Freenet state for previous flags (GAP-10)
         // Check if invitee already has history in the system
         let invitee_hash = MemberHash::from_identity(username, &self.config.pepper);
-        let has_previous_flags = state.flags.contains_key(&invitee_hash);
+        let is_ejected = state.ejected.contains(&invitee_hash);
+        let has_previous_flags = is_ejected || state.flags.contains_key(&invitee_hash);
         let previous_flag_count = if has_previous_flags {
             state
                 .flags
@@ -278,7 +279,8 @@ impl<C: SignalClient, F: crate::freenet::FreenetClient> StromaBot<C, F> {
                         .await?;
 
                     // Send confirmation PM to inviter (no assessor identity revealed)
-                    let inviter_msg = msg_inviter_confirmation(username);
+                    let inviter_msg =
+                        msg_inviter_confirmation(username, has_previous_flags, previous_flag_count);
                     self.client.send_message(sender, &inviter_msg).await
                 }
                 None => {


### PR DESCRIPTION
Implement re-entry warning system for users with previous flags.

## Changes
- Query Freenet ejected set and flags when /invite is called
- Display warning to inviter about re-entry requirements
- Warning shows previous flag count and required vouch threshold
- Add unit tests for warning message with 0, 1, and 3 flags

## Implementation
- bot.rs: Check both ejected set and flags for previous history
- vetting.rs: Update msg_inviter_confirmation with warning logic
- vetting.rs: Add 3 new unit tests for warning message variants

## Test Results
✅ All 498 tests passing including 3 new unit tests

## Related Work
Resolves: st-l6uuq (GAP-10: Complete re-entry warning with Freenet query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)