### PR TITLE
test: Fix CLI integration tests for cargo-llvm-cov (st-hi827)

### DIFF
--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -7,18 +7,21 @@ use std::process::Command;
 use tempfile::{NamedTempFile, TempDir};
 
 fn get_binary_path() -> String {
-    // The binary path will be in target/debug/ or target/release/
+    // The binary path will be in target/debug/, target/release/, or target/llvm-cov-target/debug/
     let binary_name = if cfg!(windows) {
         "stroma.exe"
     } else {
         "stroma"
     };
 
-    // Try to find the binary
+    // Try to find the binary (check llvm-cov location first since that's where it'll be during coverage runs)
+    let llvm_cov_path = format!("target/llvm-cov-target/debug/{}", binary_name);
     let debug_path = format!("target/debug/{}", binary_name);
     let release_path = format!("target/release/{}", binary_name);
 
-    if std::path::Path::new(&debug_path).exists() {
+    if std::path::Path::new(&llvm_cov_path).exists() {
+        llvm_cov_path
+    } else if std::path::Path::new(&debug_path).exists() {
         debug_path
     } else if std::path::Path::new(&release_path).exists() {
         release_path


### PR DESCRIPTION
## Summary
- Fixed CLI integration test binary path detection to support cargo-llvm-cov
- Updated get_binary_path() to check target/llvm-cov-target/debug/ first
- Resolves CI failures where tests couldn't find binary under coverage runs
- All 16 CLI integration tests now pass under cargo-llvm-cov

## Source Issue
- st-hi827: Phase 0 Gap: CLI integration tests disabled
- Worker: stromarig/polecats/obsidian
- MR Bead: st-2j5vr
- Fixes PR #79 failure

## Test Results
✅ 502 tests passed, 0 failed
✅ All quality gates passed
✅ Fixes cargo-llvm-cov binary path issue

🤖 Generated by Refinery (stromarig merge queue processor)