### PR TITLE
feat: Create StromaStore wrapper (st-ayc)

### DIFF
--- a/src/signal/bot.rs
+++ b/src/signal/bot.rs
@@ -1757,8 +1757,12 @@ mod tests {
         // Verify session was updated
         let session = bot.vetting_sessions.get_session(invitee_username).unwrap();
         assert_eq!(session.excluded_candidates.len(), 1);
-        // Status is Rejected because no assessors are available (empty state)
-        assert_eq!(session.status, VettingStatus::Rejected);
+        // Status remains PendingMatch because:
+        // 1. contract_hash is None (bootstrap phase), so re-matching can't be attempted
+        // 2. Session stays alive so invitee can be matched when network initializes
+        // 3. /reject-intro means "I can't assess" not "invitee is unsuitable"
+        //    (assessors should use /flag if invitee is a threat)
+        assert_eq!(session.status, VettingStatus::PendingMatch);
         assert!(session.assessor.is_none());
     }
 


### PR DESCRIPTION
## Summary

Create StromaStore wrapper and remove StromaProtocolStore.

## Changes
- **Create** src/signal/stroma_store.rs (~200-300 lines):
  - StromaStore(SqliteStore) newtype wrapper
  - Implement Store, StateStore, ContentsStore by delegation
  - No-op: save_message, message methods, sticker methods
  - Delegate: groups, contacts, profiles, protocol state
  - Constructor: StromaStore::open(path, passphrase)

- **Remove** src/signal/store.rs (StromaProtocolStore):
  - Delete file
  - Update src/signal/mod.rs imports
  - Update src/signal/client.rs, linking.rs, CLI files

Closes: st-ayc
Convoy: st-1us (StromaStore Wrapper Migration)
Depends on: st-w95, st-i5i
Worker: obsidian

🤖 PR created by Refinery for merge queue processing