### PR TITLE
Fix Binary Size Monitor: Static OpenSSL for musl

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -113,10 +113,10 @@ jobs:
 
       - name: Build release binary (musl)
         env:
-          # Point musl cross-compiler to system OpenSSL headers and libraries
-          OPENSSL_DIR: /usr
-          OPENSSL_INCLUDE_DIR: /usr/include
+          # Use static linking for OpenSSL to avoid glibc/musl header conflicts
+          OPENSSL_STATIC: "1"
           OPENSSL_LIB_DIR: /usr/lib/x86_64-linux-gnu
+          PKG_CONFIG_ALLOW_CROSS: "1"
         run: cargo build --release --target x86_64-unknown-linux-musl
 
       - name: Measure binary size


### PR DESCRIPTION
## Problem

PR #103's fix caused glibc/musl header conflict:
```
fatal error: bits/libc-header-start.h: No such file or directory
```

Setting `OPENSSL_INCLUDE_DIR=/usr/include` pointed musl cross-compiler to glibc headers, which are incompatible.

## Root Cause

Musl and glibc have incompatible headers. Cannot use `/usr/include` (glibc) when cross-compiling for musl target.

## Solution

Use **static OpenSSL linking** instead of system headers:

- `OPENSSL_STATIC=1` - Force static linking of OpenSSL
- `PKG_CONFIG_ALLOW_CROSS=1` - Enable cross-compilation with pkg-config
- Remove `OPENSSL_INCLUDE_DIR` - Avoid glibc headers
- Keep `OPENSSL_LIB_DIR` - Point to library location

This allows musl builds to statically link OpenSSL without header conflicts.

## Impact

Fixes Binary Size Monitor for PR #102 (st-nvn0: lift presage-store-sqlite ban).

## Verification

Will test on PR #102 after merge.

HUMAN_APPROVED: st-nvn0 (CI infrastructure fix)

🤖 PR created by mayor for CI infrastructure fix