### PR TITLE
Fix Binary Size Monitor: Use native target instead of musl

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -105,24 +105,18 @@ jobs:
         uses: ./.github/actions/rust-setup
         with:
           toolchain: stable
-          targets: x86_64-unknown-linux-musl
           cache-key: security-binary-size
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y musl-tools protobuf-compiler libssl-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libssl-dev pkg-config
 
-      - name: Build release binary (musl)
-        env:
-          # Point musl cross-compiler to system OpenSSL headers and libraries
-          OPENSSL_DIR: /usr
-          OPENSSL_INCLUDE_DIR: /usr/include
-          OPENSSL_LIB_DIR: /usr/lib/x86_64-linux-gnu
-        run: cargo build --release --target x86_64-unknown-linux-musl
+      - name: Build release binary
+        run: cargo build --release
 
       - name: Measure binary size
         id: size-check
         run: |
-          BINARY_SIZE=$(stat -c%s "target/x86_64-unknown-linux-musl/release/stroma" || echo "0")
+          BINARY_SIZE=$(stat -c%s "target/release/stroma" || echo "0")
           echo "binary_size=$BINARY_SIZE" >> $GITHUB_OUTPUT
           echo "Binary size: $(numfmt --to=iec-i --suffix=B $BINARY_SIZE)"
 


### PR DESCRIPTION
## Problem

Binary Size Monitor has failed repeatedly with musl cross-compilation + SQLCipher:

- **PR #103**: glibc/musl header conflict (`bits/libc-header-start.h`)
- **PR #104**: musl-gcc can't find OpenSSL headers (`openssl/crypto.h`)
- **Current**: Still failing despite static linking attempts

## Root Cause

SQLCipher compilation requires OpenSSL headers. Cross-compiling for musl creates incompatibilities:
1. System OpenSSL headers are glibc-based (incompatible with musl)
2. musl-gcc doesn't find headers without complex path configuration
3. Static linking still requires headers during compilation

## Solution

**Use native Linux target (`x86_64-unknown-linux-gnu`) instead of musl.**

Benefits:
- ✅ No cross-compilation complexity
- ✅ SQLCipher + OpenSSL builds cleanly with system libraries
- ✅ Binary size monitoring still works
- ✅ Simpler, more reliable CI

Trade-off:
- Binary measured on native Linux instead of musl
- **Acceptable** - we monitor size *trends*, not absolute musl size

## Changes

- Remove `musl-tools` dependency
- Remove `x86_64-unknown-linux-musl` target
- Remove all OpenSSL environment variables
- Build with `cargo build --release` (native target)
- Update binary path: `target/release/stroma`

## Impact

Fixes Binary Size Monitor for PR #102 and all future PRs with presage-store-sqlite.

HUMAN_APPROVED: st-nvn0 (CI infrastructure fix)

🤖 PR created by mayor for CI infrastructure fix