### PR TITLE
Add .gemini/ and .opencode/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ state.json
 # Gas Town (added by gt)
 .beads/
 *.info
+.gemini/
+.opencode/


### PR DESCRIPTION
## Summary
- Add .gemini/ and .opencode/ directories to gitignore to avoid committing AI assistant metadata